### PR TITLE
Fix for preference initialization issue

### DIFF
--- a/honeywellhomedriver.groovy
+++ b/honeywellhomedriver.groovy
@@ -82,6 +82,10 @@ void disableDebugLog()
 void installed()
 {
     LogInfo("Installing.");
+    heatModeEnabled = true
+    coolModeEnabled = true
+    debugLogs = false
+    descriptionText = true
     refresh()
 }
 


### PR DESCRIPTION
Found by user zahe.pitts and verified by me to be a problem with preference not being initialized, i.e. null values. Fix was suggested in this thread: https://community.hubitat.com/t/preferences-defaultvalue-when-are-they-loaded/51030